### PR TITLE
Sibling cards should be paired #5

### DIFF
--- a/src/cards.js
+++ b/src/cards.js
@@ -3,73 +3,85 @@ const cards = [
     id: 1,
     sibling_id: 2,
     front: "1",
-    flipped: false
+    flipped: false,
+    played: false
   },
   {
     id: 2,
     sibling_id: 1,
     front: "1",
-    flipped: false
+    flipped: false,
+    played: false
   },
   {
     id: 3,
     sibling_id: 4,
     front: "2",
-    flipped: false
+    flipped: false,
+    played: false
   },
   {
     id: 4,
     sibling_id: 3,
     front: "2",
-    flipped: false
+    flipped: false,
+    played: false
   },
   {
     id: 5,
     sibling_id: 6,
     front: "3",
-    flipped: false
+    flipped: false,
+    played: false
   },
   {
     id: 6,
     sibling_id: 5,
     front: "3",
-    flipped: false
+    flipped: false,
+    played: false
   },
   {
     id: 7,
     sibling_id: 8,
     front: "4",
-    flipped: false
+    flipped: false,
+    played: false
   },
   {
     id: 8,
     sibling_id: 7,
     front: "4",
-    flipped: false
+    flipped: false,
+    played: false
   },
   {
     id: 9,
     sibling_id: 10,
     front: "5",
-    flipped: false
+    flipped: false,
+    played: false
   },
   {
     id: 10,
     sibling_id: 9,
     front: "5",
-    flipped: false
+    flipped: false,
+    played: false
   },
   {
     id: 11,
     sibling_id: 12,
     front: "6",
-    flipped: false
+    flipped: false,
+    played: false
   },
   {
     id: 12,
     sibling_id: 11,
     front: "6",
-    flipped: false
+    flipped: false,
+    played: false
   }
 ];
 

--- a/src/cards.js
+++ b/src/cards.js
@@ -2,62 +2,74 @@ const cards = [
   {
     id: 1,
     sibling_id: 2,
-    front: "1"
+    front: "1",
+    flipped: false
   },
   {
     id: 2,
     sibling_id: 1,
-    front: "1"
+    front: "1",
+    flipped: false
   },
   {
     id: 3,
     sibling_id: 4,
-    front: "2"
+    front: "2",
+    flipped: false
   },
   {
     id: 4,
     sibling_id: 3,
-    front: "2"
+    front: "2",
+    flipped: false
   },
   {
     id: 5,
     sibling_id: 6,
-    front: "3"
+    front: "3",
+    flipped: false
   },
   {
     id: 6,
     sibling_id: 5,
-    front: "3"
+    front: "3",
+    flipped: false
   },
   {
     id: 7,
     sibling_id: 8,
-    front: "4"
+    front: "4",
+    flipped: false
   },
   {
     id: 8,
     sibling_id: 7,
-    front: "4"
+    front: "4",
+    flipped: false
   },
   {
     id: 9,
     sibling_id: 10,
-    front: "5"
+    front: "5",
+    flipped: false
   },
   {
     id: 10,
     sibling_id: 9,
-    front: "5"
+    front: "5",
+    flipped: false
   },
   {
     id: 11,
     sibling_id: 12,
-    front: "6"
+    front: "6",
+    flipped: false
   },
   {
     id: 12,
     sibling_id: 11,
-    front: "6"
+    front: "6",
+    flipped: false
   }
 ];
 

--- a/src/components/Board.js
+++ b/src/components/Board.js
@@ -13,16 +13,21 @@ const Grid = styled.div`
   grid-gap: 20px;
 `;
 
-const Board = ({ cards }) => (
+const Board = ({ cards, onCardClick }) => (
   <Grid>
     {cards.map(card => (
-      <CardContainer key={card.id} card={card} />
+      <CardContainer
+        key={card.id}
+        card={card}
+        onClick={() => onCardClick(card.id)}
+      />
     ))}
   </Grid>
 );
 
 Board.propTypes = {
-  cards: PropTypes.arrayOf(CardPropType).isRequired
+  cards: PropTypes.arrayOf(CardPropType).isRequired,
+  onCardClick: PropTypes.func.isRequired
 };
 
 export default Board;

--- a/src/containers/BoardContainer.js
+++ b/src/containers/BoardContainer.js
@@ -4,8 +4,65 @@ import Board from "./../components/Board";
 import cards from "./../cards";
 
 class BoardContainer extends Component {
+  state = {
+    cards: cards,
+    flippedCards: []
+  };
+
+  flipCard = id => {
+    this.setState(prevState => ({
+      cards: prevState.cards.map(card => {
+        card = Object.assign({}, card);
+        if (card.id === id) {
+          card.flipped = !card.flipped;
+        }
+        return card;
+      })
+    }));
+  };
+
+  flipCards = ids => ids.map(this.flipCard);
+
+  cardCanFlip = id => {
+    const card = this.state.cards.find(card => card.id === id);
+    return !this.isTheOnlyCardFlipped(card);
+  };
+
+  isTheOnlyCardFlipped = card =>
+    this.isAtLeastOneCardFlipped() && card.flipped ? true : false;
+
+  isAtLeastOneCardFlipped = () =>
+    this.state.cards.reduce((prev, curr) => prev || curr.flipped, false);
+
+  checkSiblings = () => {
+    const flippedCards = this.state.cards.filter(card => card.flipped);
+
+    if (flippedCards[0].id !== flippedCards[1].sibling_id) {
+      this.flipCards([flippedCards[0].id, flippedCards[1].id]);
+      return;
+    }
+  };
+
+  handleCardClick = id => {
+    const card = this.state.cards.find(card => card.id === id);
+    if (this.cardCanFlip(id)) {
+      this.flipCard(id);
+      this.setState(prevState => ({
+        flippedCards: [...prevState.flippedCards, id]
+      }));
+    }
+
+    const flippedCards = this.state.cards.filter(card => card.flipped);
+
+    if (flippedCards.length > 1) {
+      this.checkSiblings();
+    }
+  };
+
   render() {
-    return <Board cards={cards} />;
+    return (
+      <Board cards={this.state.cards} onCardClick={this.handleCardClick} />
+    );
   }
 }
 

--- a/src/containers/BoardContainer.js
+++ b/src/containers/BoardContainer.js
@@ -9,70 +9,65 @@ class BoardContainer extends Component {
     flippedCards: []
   };
 
-  flipCard = card => {
+  flipCard = id => {
     this.setState(prevState => ({
-      cards: prevState.cards.map(stateCard => {
-        stateCard = Object.assign({}, stateCard);
-        if (stateCard.id === card.id) {
-          stateCard.flipped = !stateCard.flipped;
-          card = stateCard;
-        }
-        return stateCard;
-      }),
+      cards: prevState.cards.map(card => {
+        return id === card.id
+          ? Object.assign({}, card, { flipped: !card.flipped })
+          : Object.assign({}, card);
+      })
+    }));
+  };
+
+  flipCards = cards => cards.map(card => this.flipCard(card.id));
+
+  addFlippedCard = card => {
+    card = Object.assign({}, card, { flipped: true });
+    this.setState(prevState => ({
       flippedCards:
-        prevState.flippedCards.length > 1
-          ? [Object.assign({}, card)]
-          : [...this.state.flippedCards, Object.assign({}, card)]
+        prevState.flippedCards.length < 2
+          ? [...prevState.flippedCards, card]
+          : [card]
     }));
   };
 
-  flipCards = cards => cards.map(this.flipCard);
-
-  playCard = card => {
+  playCard = id => {
     this.setState(prevState => ({
-      cards: prevState.cards.map(stateCard => {
-        stateCard = Object.assign({}, stateCard);
-        if (stateCard.id === card.id) {
-          stateCard.played = true;
-        }
-
-        return stateCard;
-      }),
-      flippedCards: prevState.flippedCards.filter(
-        flipped => flipped.id !== card.id
-      )
+      cards: prevState.cards.map(card => {
+        return id === card.id
+          ? Object.assign({}, card, { played: true })
+          : Object.assign({}, card);
+      })
     }));
   };
 
-  playCards = () => this.state.flippedCards.map(this.playCard);
-
-  clearFlipped = card => {
-    this.flipCards(this.state.flippedCards);
-    this.setState(prevState => ({
-      ...prevState,
-      flippedCards: [Object.assign({}, card)]
-    }));
-  };
+  playCards = () => this.state.flippedCards.map(card => this.playCard(card.id));
 
   cardCanFlip = card =>
     !card.played && !(this.state.flippedCards.length && card.flipped);
 
-  checkFlippedCards = card => {
-    const wrongCards =
-      this.state.flippedCards[0].id !== this.state.flippedCards[1].sibling_id;
-    if (wrongCards) {
-      this.clearFlipped(card);
-    } else {
+  areFlippedCardsPair = () =>
+    this.state.flippedCards[0].id === this.state.flippedCards[1].sibling_id;
+
+  verifyFlippedCards = card => {
+    if (this.areFlippedCardsPair()) {
       this.playCards();
     }
+    this.flipCards(this.state.flippedCards);
   };
 
   handleCardClick = id => {
     const card = this.state.cards.find(card => card.id === id);
-    if (this.cardCanFlip(card)) this.flipCard(card);
+
+    if (!this.cardCanFlip(card)) {
+      return;
+    }
+
+    this.flipCard(card.id);
+    this.addFlippedCard(card);
 
     if (this.state.flippedCards.length > 1) {
-      this.checkFlippedCards(card);
+      this.verifyFlippedCards(card);
     }
   };
 

--- a/src/containers/BoardContainer.js
+++ b/src/containers/BoardContainer.js
@@ -9,53 +9,70 @@ class BoardContainer extends Component {
     flippedCards: []
   };
 
-  flipCard = id => {
+  flipCard = card => {
     this.setState(prevState => ({
-      cards: prevState.cards.map(card => {
-        card = Object.assign({}, card);
-        if (card.id === id) {
-          card.flipped = !card.flipped;
+      cards: prevState.cards.map(stateCard => {
+        stateCard = Object.assign({}, stateCard);
+        if (stateCard.id === card.id) {
+          stateCard.flipped = !stateCard.flipped;
+          card = stateCard;
         }
-        return card;
-      })
+        return stateCard;
+      }),
+      flippedCards:
+        prevState.flippedCards.length > 1
+          ? [Object.assign({}, card)]
+          : [...this.state.flippedCards, Object.assign({}, card)]
     }));
   };
 
-  flipCards = ids => ids.map(this.flipCard);
+  flipCards = cards => cards.map(this.flipCard);
 
-  cardCanFlip = id => {
-    const card = this.state.cards.find(card => card.id === id);
-    return !this.isTheOnlyCardFlipped(card);
+  playCard = card => {
+    this.setState(prevState => ({
+      cards: prevState.cards.map(stateCard => {
+        stateCard = Object.assign({}, stateCard);
+        if (stateCard.id === card.id) {
+          stateCard.played = true;
+        }
+
+        return stateCard;
+      }),
+      flippedCards: prevState.flippedCards.filter(
+        flipped => flipped.id !== card.id
+      )
+    }));
   };
 
-  isTheOnlyCardFlipped = card =>
-    this.isAtLeastOneCardFlipped() && card.flipped ? true : false;
+  playCards = () => this.state.flippedCards.map(this.playCard);
 
-  isAtLeastOneCardFlipped = () =>
-    this.state.cards.reduce((prev, curr) => prev || curr.flipped, false);
+  clearFlipped = card => {
+    this.flipCards(this.state.flippedCards);
+    this.setState(prevState => ({
+      ...prevState,
+      flippedCards: [Object.assign({}, card)]
+    }));
+  };
 
-  checkSiblings = () => {
-    const flippedCards = this.state.cards.filter(card => card.flipped);
+  cardCanFlip = card =>
+    !card.played && !(this.state.flippedCards.length && card.flipped);
 
-    if (flippedCards[0].id !== flippedCards[1].sibling_id) {
-      this.flipCards([flippedCards[0].id, flippedCards[1].id]);
-      return;
+  checkFlippedCards = card => {
+    const wrongCards =
+      this.state.flippedCards[0].id !== this.state.flippedCards[1].sibling_id;
+    if (wrongCards) {
+      this.clearFlipped(card);
+    } else {
+      this.playCards();
     }
   };
 
   handleCardClick = id => {
     const card = this.state.cards.find(card => card.id === id);
-    if (this.cardCanFlip(id)) {
-      this.flipCard(id);
-      this.setState(prevState => ({
-        flippedCards: [...prevState.flippedCards, id]
-      }));
-    }
+    if (this.cardCanFlip(card)) this.flipCard(card);
 
-    const flippedCards = this.state.cards.filter(card => card.flipped);
-
-    if (flippedCards.length > 1) {
-      this.checkSiblings();
+    if (this.state.flippedCards.length > 1) {
+      this.checkFlippedCards(card);
     }
   };
 

--- a/src/containers/CardContainer.js
+++ b/src/containers/CardContainer.js
@@ -1,30 +1,24 @@
 import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 import Card from "./../components/Card";
 import CardPropType from "./../propTypes/CardPropType";
 
 class CardContainer extends Component {
-  state = {
-    flipped: false
-  };
-
-  flip = () => {
-    this.setState(prevState => {
-      return { flipped: !prevState.flipped };
-    });
-  };
-
   handleClick = () => {
-    this.flip();
+    this.props.onClick();
   };
 
   render() {
-    return <Card flipped={this.state.flipped} onClick={this.handleClick} />;
+    return (
+      <Card flipped={this.props.card.flipped} onClick={this.handleClick} />
+    );
   }
 }
 
 CardContainer.propTypes = {
-  card: CardPropType.isRequired
+  card: CardPropType.isRequired,
+  onClick: PropTypes.func.isRequired
 };
 
 export default CardContainer;

--- a/src/propTypes/CardPropType.js
+++ b/src/propTypes/CardPropType.js
@@ -3,7 +3,8 @@ import PropTypes from "prop-types";
 const CardPropType = PropTypes.shape({
   id: PropTypes.number.isRequired,
   sibling_id: PropTypes.number.isRequired,
-  front: PropTypes.string.isRequired
+  front: PropTypes.string.isRequired,
+  flipped: PropTypes.bool.isRequired
 });
 
 export default CardPropType;

--- a/src/propTypes/CardPropType.js
+++ b/src/propTypes/CardPropType.js
@@ -4,7 +4,8 @@ const CardPropType = PropTypes.shape({
   id: PropTypes.number.isRequired,
   sibling_id: PropTypes.number.isRequired,
   front: PropTypes.string.isRequired,
-  flipped: PropTypes.bool.isRequired
+  flipped: PropTypes.bool.isRequired,
+  played: PropTypes.bool.isRequired
 });
 
 export default CardPropType;

--- a/src/tests/components/Board.test.js
+++ b/src/tests/components/Board.test.js
@@ -5,39 +5,72 @@ import Board from "./../../components/Board";
 import CardContainer from "./../../containers/CardContainer";
 
 describe("Board", () => {
+  let wrapper;
+  const onCardClick = jest.fn();
+  const cards = [
+    {
+      id: 1,
+      sibling_id: 2,
+      front: "1",
+      flipped: false
+    },
+    {
+      id: 2,
+      sibling_id: 1,
+      front: "1",
+      flipped: false
+    }
+  ];
+
+  beforeEach(() => {
+    wrapper = shallow(<Board cards={cards} onCardClick={onCardClick} />);
+  });
+
+  afterEach(() => {
+    onCardClick.mockClear();
+  });
+
   describe("props", () => {
     it("must receive cards", () => {
-      expect(() => shallow(<Board />)).toThrow();
+      expect(() => shallow(<Board onCardClick={onCardClick} />)).toThrow();
     });
 
     it("cards must be an array", () => {
-      expect(() => shallow(<Board cards={1} />)).toThrow();
+      expect(() =>
+        shallow(<Board cards={1} onCardClick={onCardClick} />)
+      ).toThrow();
     });
 
     it("cards must be an array of valid cards", () => {
       const cards = [42];
+      expect(() =>
+        shallow(<Board cards={cards} onCardClick={onCardClick} />)
+      ).toThrow();
+    });
+
+    it("must receive `onCardClick` prop", () => {
       expect(() => shallow(<Board cards={cards} />)).toThrow();
+    });
+
+    it("`onCardClick` prop should be a function", () => {
+      expect(() => shallow(<Board cards={cards} onCardClick={1} />)).toThrow();
     });
   });
 
   it("should render 2 `CardContainer`", () => {
-    const cards = [
-      {
-        id: 1,
-        sibling_id: 2,
-        front: "1"
-      },
-      {
-        id: 2,
-        sibling_id: 1,
-        front: "1"
-      }
-    ];
-    const board = shallow(<Board cards={cards} />);
-    cards.map(card => {
-      expect(
-        board.contains(<CardContainer key={card.id} card={card} />)
-      ).toBeTruthy();
+    expect(wrapper.find(CardContainer).length).toBe(2);
+  });
+
+  describe("User clicks a card", () => {
+    let card;
+    beforeEach(() => {
+      card = wrapper.find(CardContainer).first();
+      card.simulate("click");
+    });
+
+    it("and `onCardClick` prop should be called with the card ID", () => {
+      const call = onCardClick.mock.calls[0];
+      expect(call[0]).toBe(card.props().card.id);
     });
   });
 });

--- a/src/tests/components/Board.test.js
+++ b/src/tests/components/Board.test.js
@@ -12,13 +12,15 @@ describe("Board", () => {
       id: 1,
       sibling_id: 2,
       front: "1",
-      flipped: false
+      flipped: false,
+      played: false
     },
     {
       id: 2,
       sibling_id: 1,
       front: "1",
-      flipped: false
+      flipped: false,
+      played: false
     }
   ];
 

--- a/src/tests/containers/BoardContainer.test.js
+++ b/src/tests/containers/BoardContainer.test.js
@@ -35,16 +35,34 @@ describe("BoardContainer", () => {
     });
 
     describe("Then clicks another card", () => {
-      beforeEach(() => {
-        const board = wrapper.find(Board).first();
-        board.simulate("cardClick", 3);
-      });
-
       describe("and they are not siblings", () => {
+        beforeEach(() => {
+          const board = wrapper.find(Board).first();
+          board.simulate("cardClick", 3);
+        });
+
         it("both cards should flip back", () => {
           expect(wrapper.state().cards[0].flipped).toBeFalsy();
           expect(wrapper.state().cards[2].flipped).toBeFalsy();
         });
+      });
+
+      describe("and they are siblings", () => {
+        beforeEach(() => {
+          const board = wrapper.find(Board).first();
+          board.simulate("cardClick", 2);
+        });
+
+        it("both cards should not be playable anymore", () => {
+          expect(wrapper.state().cards[0].played).toBeTruthy();
+          expect(wrapper.state().cards[1].played).toBeTruthy();
+        });
+
+        // it("should not be clickeable after played", () => {
+        //   const board = wrapper.find(Board).first();
+        //   board.simulate("cardClick", 1);
+        //   expect(wrapper.state().cards[0].flipped).toBeFalsy();
+        // });
       });
     });
 

--- a/src/tests/containers/BoardContainer.test.js
+++ b/src/tests/containers/BoardContainer.test.js
@@ -10,10 +10,6 @@ describe("BoardContainer", () => {
     wrapper = shallow(<BoardContainer />);
   });
 
-  it("Renders a `Board`", () => {
-    expect(wrapper.find(Board).length).toBe(1);
-  });
-
   it("Pass cards state to `Board` as props", () => {
     const board = wrapper.find(Board).first();
     expect(board.props().cards).toEqual(wrapper.state().cards);
@@ -35,6 +31,10 @@ describe("BoardContainer", () => {
     });
 
     describe("Then clicks another card", () => {
+      beforeEach(() => {
+        jest.useFakeTimers();
+      });
+
       describe("and they are not siblings", () => {
         beforeEach(() => {
           const board = wrapper.find(Board).first();
@@ -42,8 +42,16 @@ describe("BoardContainer", () => {
         });
 
         it("both cards should flip back", () => {
+          jest.runAllTimers();
           expect(wrapper.state().cards[0].flipped).toBeFalsy();
           expect(wrapper.state().cards[2].flipped).toBeFalsy();
+        });
+
+        it("clicks a third one and should not flip", () => {
+          const board = wrapper.find(Board).first();
+          board.simulate("cardClick", 4);
+          jest.runAllTimers();
+          expect(wrapper.state().cards[3].flipped).toBeFalsy();
         });
       });
 
@@ -54,14 +62,25 @@ describe("BoardContainer", () => {
         });
 
         it("both cards should not be playable anymore", () => {
+          jest.runAllTimers();
           expect(wrapper.state().cards[0].played).toBeTruthy();
           expect(wrapper.state().cards[1].played).toBeTruthy();
         });
 
-        it("should not be clickeable after played", () => {
+        it("both cards should not be clickeable after played", () => {
+          jest.runAllTimers();
           const board = wrapper.find(Board).first();
           board.simulate("cardClick", 1);
-          expect(wrapper.state().cards[0].flipped).toBeFalsy();
+          board.simulate("cardClick", 2);
+          expect(wrapper.state().cards[0].flipped).toBeTruthy();
+          expect(wrapper.state().cards[1].flipped).toBeTruthy();
+        });
+
+        it("clicks a third one and should not flip", () => {
+          const board = wrapper.find(Board).first();
+          board.simulate("cardClick", 4);
+          jest.runAllTimers();
+          expect(wrapper.state().cards[3].flipped).toBeFalsy();
         });
       });
     });

--- a/src/tests/containers/BoardContainer.test.js
+++ b/src/tests/containers/BoardContainer.test.js
@@ -3,7 +3,6 @@ import { shallow } from "enzyme";
 
 import BoardContainer from "./../../containers/BoardContainer";
 import Board from "./../../components/Board";
-import cards from "./../../cards";
 
 describe("BoardContainer", () => {
   let wrapper;
@@ -15,8 +14,51 @@ describe("BoardContainer", () => {
     expect(wrapper.find(Board).length).toBe(1);
   });
 
-  it("Pass cards to `Board` as props", () => {
-    const renderedBoard = wrapper.find(Board).first();
-    expect(renderedBoard.props().cards).toEqual(cards);
+  it("Pass cards state to `Board` as props", () => {
+    const board = wrapper.find(Board).first();
+    expect(board.props().cards).toEqual(wrapper.state().cards);
+  });
+
+  describe("User clicks a card", () => {
+    beforeEach(() => {
+      const board = wrapper.find(Board).first();
+      board.simulate("cardClick", 1);
+    });
+
+    it("and the card should flip", () => {
+      const cards = wrapper.state().cards.map(card => {
+        return Object.assign({}, card);
+      });
+      cards[0].flipped = true;
+      expect(wrapper.state().cards[0].flipped).toBeTruthy();
+      expect(wrapper.state().cards).toEqual(cards);
+    });
+
+    describe("Then clicks another card", () => {
+      beforeEach(() => {
+        const board = wrapper.find(Board).first();
+        board.simulate("cardClick", 3);
+      });
+
+      describe("and they are not siblings", () => {
+        it("both cards should flip back", () => {
+          expect(wrapper.state().cards[0].flipped).toBeFalsy();
+          expect(wrapper.state().cards[2].flipped).toBeFalsy();
+        });
+      });
+    });
+
+    describe("and then clicks it once again", () => {
+      beforeEach(() => {
+        const board = wrapper.find(Board).first();
+        board.simulate("cardClick", 1);
+      });
+
+      describe("but is the only card flipped", () => {
+        it("should not flip back", () => {
+          expect(wrapper.state().cards[0].flipped).toBeTruthy();
+        });
+      });
+    });
   });
 });

--- a/src/tests/containers/BoardContainer.test.js
+++ b/src/tests/containers/BoardContainer.test.js
@@ -58,11 +58,11 @@ describe("BoardContainer", () => {
           expect(wrapper.state().cards[1].played).toBeTruthy();
         });
 
-        // it("should not be clickeable after played", () => {
-        //   const board = wrapper.find(Board).first();
-        //   board.simulate("cardClick", 1);
-        //   expect(wrapper.state().cards[0].flipped).toBeFalsy();
-        // });
+        it("should not be clickeable after played", () => {
+          const board = wrapper.find(Board).first();
+          board.simulate("cardClick", 1);
+          expect(wrapper.state().cards[0].flipped).toBeFalsy();
+        });
       });
     });
 

--- a/src/tests/containers/CardContainer.test.js
+++ b/src/tests/containers/CardContainer.test.js
@@ -6,13 +6,19 @@ import Card from "./../../components/Card";
 
 describe("CardContainer", () => {
   let wrapper;
+  const onClick = jest.fn();
   beforeEach(() => {
-    let card = {
+    const card = {
       id: 1,
       sibling_id: 2,
-      front: "#FFF"
+      front: "#FFF",
+      flipped: false
     };
-    wrapper = shallow(<CardContainer card={card} />);
+    wrapper = shallow(<CardContainer card={card} onClick={onClick} />);
+  });
+
+  afterEach(() => {
+    onClick.mockClear();
   });
 
   describe("props", () => {
@@ -27,13 +33,33 @@ describe("CardContainer", () => {
         shallow(<CardContainer card={{}} />);
       }).toThrow();
     });
+
+    it("must receive `onClick` prop", () => {
+      const card = {
+        id: 1,
+        sibling_id: 2,
+        front: "#FFF",
+        flipped: false
+      };
+      expect(() => {
+        shallow(<CardContainer card={card} />);
+      }).toThrow();
+
+      it("`onClick` should be a function", () => {
+        const card = {
+          id: 1,
+          sibling_id: 2,
+          front: "#FFF",
+          flipped: false
+        };
+        expect(() => {
+          shallow(<CardContainer card={card} onClick={1} />);
+        }).toThrow();
+      });
+    });
   });
 
-  it("should not be flipped", () => {
-    expect(wrapper.state().flipped).toBeFalsy();
-  });
-
-  it("pass flipped state to the Card", () => {
+  it("pass flipped as false to the Card", () => {
     expect(wrapper.find(Card).props().flipped).toBeFalsy();
   });
 
@@ -45,23 +71,8 @@ describe("CardContainer", () => {
         .simulate("click");
     });
 
-    it("and the card flips", () => {
-      expect(wrapper.state().flipped).toBeTruthy();
-      expect(wrapper.find(Card).props().flipped).toBeTruthy();
-    });
-
-    describe("and clicks the card again", () => {
-      beforeEach(() => {
-        wrapper
-          .find(Card)
-          .first()
-          .simulate("click");
-      });
-
-      it("and the card flips", () => {
-        expect(wrapper.state().flipped).toBeFalsy();
-        expect(wrapper.find(Card).props().flipped).toBeFalsy();
-      });
+    it("and it calls `onClick` prop", () => {
+      expect(onClick.mock.calls.length).toBe(1);
     });
   });
 });

--- a/src/tests/containers/CardContainer.test.js
+++ b/src/tests/containers/CardContainer.test.js
@@ -12,7 +12,8 @@ describe("CardContainer", () => {
       id: 1,
       sibling_id: 2,
       front: "#FFF",
-      flipped: false
+      flipped: false,
+      played: false
     };
     wrapper = shallow(<CardContainer card={card} onClick={onClick} />);
   });
@@ -39,7 +40,8 @@ describe("CardContainer", () => {
         id: 1,
         sibling_id: 2,
         front: "#FFF",
-        flipped: false
+        flipped: false,
+        played: false
       };
       expect(() => {
         shallow(<CardContainer card={card} />);
@@ -50,7 +52,8 @@ describe("CardContainer", () => {
           id: 1,
           sibling_id: 2,
           front: "#FFF",
-          flipped: false
+          flipped: false,
+          played: false
         };
         expect(() => {
           shallow(<CardContainer card={card} onClick={1} />);


### PR DESCRIPTION
# Description

Sibling cards are paired and counted as played.
Wrong cards are flipped back.


Fixes #5 

# Checklist:

- [ ] I'm already part of the contributors list. Don't know how to add yourself? You can use [this tool](https://github.com/jfmengels/all-contributors-cli).
- [X] Tests are included.